### PR TITLE
Rename tag_env to env

### DIFF
--- a/insights_connexion/config.py
+++ b/insights_connexion/config.py
@@ -8,11 +8,11 @@ config_parser = configparser.ConfigParser()
 config_parser.read('config.ini')
 
 if 'test' in sys.argv[0]:
-    tag_env = 'test'
+    env = 'test'
 else:
-    tag_env = os.environ.get('INSIGHTS_CONNEXION_ENV', 'dev')
+    env = os.environ.get('INSIGHTS_CONNEXION_ENV', 'dev')
 
-config = config_parser[tag_env]
+config = config_parser[env]
 
 for key in config:
     try:


### PR DESCRIPTION
The package is no longer an integral part of the tagging service. The [_tag_env_](https://github.com/RedHatInsights/insights_connexion/compare/master...Glutexo:rename_tag_env?expand=1#diff-3844a363a12d2ab58404fec0244a76a2R11) variable name is thus misleading. Renamed to just _env_.